### PR TITLE
EchoForm; CSS for char-count - not working across all websites

### DIFF
--- a/echoform.css
+++ b/echoform.css
@@ -67,3 +67,11 @@ div.echo-submit{
   padding: 50px 50px 20px 275px;
 
 }
+
+#char-count {
+  float: right;
+  padding-top: 15px;
+  padding-right: 20px;
+  position: relative;
+}
+


### PR DESCRIPTION
@stevecass CSS is at the bottom of echoform.css for the char-count ID. Let me know if you come across what could be causing this issue and I'll keep digging for solutions in the meantime as well.
