### PR TITLE
Set boolean to fix excess error reports in Chrome.

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -70,6 +70,7 @@ function hideSpawnedEcho() {
     if (!checkClickEventWithinForm(event, echoFrame)) {
       body.removeChild(echoFrame);
       echoFormExists = false;
+      spawnedEcho = false;
     }
   }
 };


### PR DESCRIPTION
An excess error report that came up while looking for the e key bug.
